### PR TITLE
Add variable for fail fast initialize

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ cas_ldap:
     authn_searchFilter: "sAMAccountName={user}"
     userFilter: ""
     usePpolicy: "false"
-    allowMultipleDns: "true
+    allowMultipleDns: "true"
+    failFastInitialize: "true"
 ```
 
 You can optionally configure CAS to act as a client against a SAML ID provider. Learn about CAS and SAML to discover how to configure these values.

--- a/templates/cas.properties.j2
+++ b/templates/cas.properties.j2
@@ -777,6 +777,9 @@ ldap{{ loop.index }}.domain={{ ldap.domain }}
 # Should LDAP Password Policy be enabled?
 ldap{{ loop.index }}.usePpolicy={{ ldap.usePpolicy }}
 
+# Should initialization fail if we can't talk to this backend?
+ldap{{ loop.index }}.failFastInitialize={{ ldap.failFastInitialize }}
+
 # Allow multiple DNs during authentication?
 ldap{{ loop.index }}.allowMultipleDns={{ ldap.allowMultipleDns }}
 {% endfor %}

--- a/templates/deployerConfigContext.xml.j2
+++ b/templates/deployerConfigContext.xml.j2
@@ -93,7 +93,7 @@
         allowMultipleDns="${ldap{{ loop.index }}.allowMultipleDns:false}"
         connectTimeout="${ldap{{ loop.index }}.connectTimeout}"
         validateOnCheckOut="${ldap{{ loop.index }}.pool.validateOnCheckout}"
-        failFastInitialize="true"
+        failFastInitialize="${ldap{{ loop.index }}.failFastInitialize:true}"
         blockWaitTime="${ldap{{ loop.index }}.pool.blockWaitTime}"
         idleTime="${ldap{{ loop.index }}.pool.idleTime}"
         baseDn="${ldap{{ loop.index }}.baseDn}"


### PR DESCRIPTION
* Adds `failFastInitialize` variable to LDAP connections definition
* Sets that value for `cas.properties` and uses it in `deployerConfigContext.xml`
* Doesn't set an Ansible default for `failFastInitialize`, but does specify `true` as the default for the corresponding Spring property in `deployerConfigContext.xml` (following previous practice). 

## Motivation and Context

We don't always want the CAS service to fail to start when it can't talk to a defined backend. 
Closes #10.

## Testing
Tested in vagrant: verified that values get set as expected and that broken LDAP backends don't prevent CAS startup when `failFastInitialize` is `false`.


 