### PR TITLE
Run scripts required to set facts even in check mode.

### DIFF
--- a/tasks/build.yml
+++ b/tasks/build.yml
@@ -37,6 +37,7 @@
   shell: >
    cat /etc/cas/tgc.encryption.key.json | jq --raw-output '.k'
   register: cas_tgc_encryption_key
+  check_mode: no        
 
 - name: Set encryption key value as fact
   set_fact:
@@ -46,6 +47,7 @@
   shell: >
    cat /etc/cas/tgc.signing.key.json | jq --raw-output '.k'
   register: cas_tgc_signing_key
+  check_mode: no        
 
 - name: Set signing key value as fact
   set_fact:


### PR DESCRIPTION
Add `check_mode: no` so that shell commands required to set facts run even when the playbooks is run in `--check-mode`.  

The shell commands just query values, so no changes to the commands themselves were necessary to avoid side effects in check mode. 